### PR TITLE
Add security headers and more badges in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Classes [![Build Status](https://travis-ci.com/hellodavie/shs_classes.svg?branch=master)](https://travis-ci.com/hellodavie/shs_classes)
+# Classes [![Build Status](https://travis-ci.com/hellodavie/shs_classes.svg?branch=master)](https://travis-ci.com/hellodavie/shs_classes) ![License](https://img.shields.io/badge/license-MIT-green)
 A blazing fast, modern, tested, and trusted timetable app for Sydney Boys High School. 
 Previously known as [lordhelix.tk](https://lordhelix.tk/).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
-# Classes [![Build Status](https://travis-ci.com/hellodavie/shs_classes.svg?branch=master)](https://travis-ci.com/hellodavie/shs_classes) ![License](https://img.shields.io/badge/license-MIT-green)
+# Classes
+[![Build Status](https://travis-ci.com/hellodavie/shs_classes.svg?branch=master)](https://travis-ci.com/hellodavie/shs_classes)
+![License](https://img.shields.io/badge/license-MIT-green)
+![GitHub package.json version](https://img.shields.io/github/package-json/v/hellodavie/shs_classes)
+[![Server Status](https://img.shields.io/website?label=status&url=https%3A%2F%2Fshsclasses.hellodavie.com)](https://shsclasses.hellodavie.com/)
+![Mozilla HTTP Observatory Grade](https://img.shields.io/mozilla-observatory/grade/shsclasses.hellodavie.com?publish)
+
+
 A blazing fast, modern, tested, and trusted timetable app for Sydney Boys High School. 
 Previously known as [lordhelix.tk](https://lordhelix.tk/).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4937,6 +4937,11 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
+    "helmet": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-4.1.1.tgz",
+      "integrity": "sha512-Avg4XxSBrehD94mkRwEljnO+6RZx7AGfk8Wa6K1nxaU+hbXlFOhlOIMgPfFqOYQB/dBCsTpootTGuiOG+CHiQA=="
+    },
     "hex-color-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "connect-pg-simple": "^6.2.1",
     "express": "^4.13.3",
     "express-session": "^1.11.3",
+    "helmet": "^4.1.1",
     "knex": "^0.19.3",
     "pg": "^7.12.1",
     "simple-oauth2": "^0.2.1"

--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const session = require('express-session');
 const compression = require('compression');
+const helmet = require('helmet');
 const path = require('path');
 const pgSession = require('connect-pg-simple')(session);
 
@@ -11,6 +12,32 @@ const app = express();
 
 app.use(compression());
 
+app.use(
+  helmet({
+    ieNoOpen: false,
+    permittedCrossDomainPolicies: false,
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'self'"],
+        baseUri: ["'self'"],
+        fontSrc: ["'self'", "https:", "data:"],
+        frameAncestors: ["'self'"],
+        imgSrc: ["'self'", "data:", "www.google-analytics.com", "hellodavie.com"],
+        objectSrc: ["'none'"],
+        styleSrc: ["'self'", "https:", "'unsafe-inline'"],
+        scriptSrc: ["'self'", "www.google-analytics.com"],
+        manifestSrc: ["'self'"],
+        workerSrc: ["'self'"],
+        connectSrc: ["'self'", "https://*.sbhs.net.au", "www.google-analytics.com", "stats.g.doubleclick.net"],
+        upgradeInsecureRequests: [],
+      }
+    },
+    hsts: {
+      includeSubDomains: false
+    }
+  })
+);
+
 app.use(session({
   store: process.env.NODE_ENV === 'production' ? new pgSession({
     conString: process.env.DATABASE_URL
@@ -18,7 +45,7 @@ app.use(session({
   secret: process.env.COOKIE_SECRET,
   saveUninitialized: false,
   resave: false,
-  cookie: {maxAge: 90 * 24 * 60 * 60 * 1000} // 90 Days
+  cookie: { maxAge: 90 * 24 * 60 * 60 * 1000 } // 90 Days
 }));
 
 // Redirect all www requests to non-www


### PR DESCRIPTION
Added various HTTP secutiry headers including content security policy and strict transport security. Also includes various badges to make the readme even more pretty, e.g. Mozilla Observatory grading, version number, and server status.